### PR TITLE
FEC-11065 Chromecast - start time doesn't working during the casting.…

### DIFF
--- a/OTTSample/OTTSample/GoogleChromeCast/GoogleCastManager.swift
+++ b/OTTSample/OTTSample/GoogleChromeCast/GoogleCastManager.swift
@@ -78,7 +78,7 @@ class GoogleCastManager: NSObject, GCKRequestDelegate {
         return mediaInformation
     }
     
-    private func load(mediaInformation:GCKMediaInformation, appending: Bool) -> Void {
+    private func load(mediaInformation:GCKMediaInformation, appending: Bool, startTime: TimeInterval?) -> Void {
         guard let remoteMediaClient = GCKCastContext.sharedInstance().sessionManager.currentCastSession?.remoteMediaClient else { return }
        
         let mediaQueueItemBuilder = GCKMediaQueueItemBuilder()
@@ -91,7 +91,12 @@ class GoogleCastManager: NSObject, GCKRequestDelegate {
         let mediaQueueItem = mediaQueueItemBuilder.build()
         
         if appending {
-          let request = remoteMediaClient.queueInsert(mediaQueueItem, beforeItemWithID: kGCKMediaQueueInvalidItemID)
+            let request: GCKRequest
+            if let startTime = startTime {
+                request = remoteMediaClient.queueInsertAndPlay(mediaQueueItem, beforeItemWithID: kGCKMediaQueueInvalidItemID, playPosition: startTime, customData: nil)
+            } else {
+                request = remoteMediaClient.queueInsert(mediaQueueItem, beforeItemWithID: kGCKMediaQueueInvalidItemID)
+            }
           request.delegate = self
         } else {
           let queueDataBuilder = GCKMediaQueueDataBuilder(queueType: .generic)
@@ -101,6 +106,10 @@ class GoogleCastManager: NSObject, GCKRequestDelegate {
           let mediaLoadRequestDataBuilder = GCKMediaLoadRequestDataBuilder()
           mediaLoadRequestDataBuilder.mediaInformation = mediaInformation
           mediaLoadRequestDataBuilder.queueData = queueDataBuilder.build()
+            
+            if let startTime = startTime {
+                mediaLoadRequestDataBuilder.startTime = startTime
+            }
 
           let request = remoteMediaClient.loadMedia(with: mediaLoadRequestDataBuilder.build())
           request.delegate = self
@@ -160,7 +169,7 @@ class GoogleCastManager: NSObject, GCKRequestDelegate {
             gckMediaInformation = try getCAFMediaInformation(from: videoData)
             
             if let mediaInformation = gckMediaInformation {
-                self.load(mediaInformation: mediaInformation, appending: false)
+                self.load(mediaInformation: mediaInformation, appending: false, startTime: videoData.media.startTime)
             }
             
         } catch {

--- a/OVPSample/OVPSample/Info.plist
+++ b/OVPSample/OVPSample/Info.plist
@@ -22,7 +22,7 @@
 	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
-		<key>NSAllowsLocalNetworking</key>
+		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
 	<key>NSBluetoothAlwaysUsageDescription</key>


### PR DESCRIPTION
Solves FEC-11065
Chromecast - start time doesn't working during the casting.
Fixed for OTT and OVP samples